### PR TITLE
Fix cran notes about missing package anchors in documentation fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,7 @@ Roxygen: list()
 Package: strvalidator
 Type: Package
 Title: Process Control and Validation of Forensic STR Kits
-Version: 2.4.1.9006
-Author: Oskar Hansson
-Maintainer: Oskar Hansson <oskhan@ous-hf.no>
+Version: 2.4.1.9007
 URL: https://sites.google.com/site/forensicapps/strvalidator
 BugReports: https://github.com/OskarHansson/strvalidator/issues
 Authors@R: person(given = "Oskar", family = "Hansson", role = c("aut", "cre"), email = "oskhan@ous-hf.no")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Author: Oskar Hansson
 Maintainer: Oskar Hansson <oskhan@ous-hf.no>
 URL: https://sites.google.com/site/forensicapps/strvalidator
 BugReports: https://github.com/OskarHansson/strvalidator/issues
+Authors@R: person(given = "Oskar", family = "Hansson", role = c("aut", "cre"), email = "oskhan@ous-hf.no")
 Depends: R (>= 3.6.0)
 Imports:
     ggplot2 (>= 2.0.0),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Version 2.4.1.9007
+------------------------------------------------------------------------------
+* Bug fixes and improvements with the most significant listed below:
+  Adding missing package anchors in documentation fields. 
+
 Version 2.4.1.9006
 ------------------------------------------------------------------------------
 * Bug fixes and improvements with the most significant listed below:

--- a/R/calculateAllele.R
+++ b/R/calculateAllele.R
@@ -36,7 +36,7 @@
 #'
 #' @importFrom data.table data.table := .N
 #'
-#' @return data.fra[data.table]me with columns 'Marker', 'Allele', 'Peaks', 'Size.Min',
+#' @return data.frame with columns 'Marker', 'Allele', 'Peaks', 'Size.Min',
 #' 'Size.Mean', 'Size.Max', 'Height.Min', 'Height.Mean', 'Height.Max',
 #' 'Total.Peaks', 'Allele.Proportion', 'Sum.Peaks', and 'Allele.Frequency'.
 

--- a/R/calculateAllele.R
+++ b/R/calculateAllele.R
@@ -36,12 +36,12 @@
 #'
 #' @importFrom data.table data.table := .N
 #'
-#' @return data.frame with columns 'Marker', 'Allele', 'Peaks', 'Size.Min',
+#' @return data.fra[data.table]me with columns 'Marker', 'Allele', 'Peaks', 'Size.Min',
 #' 'Size.Mean', 'Size.Max', 'Height.Min', 'Height.Mean', 'Height.Max',
 #' 'Total.Peaks', 'Allele.Proportion', 'Sum.Peaks', and 'Allele.Frequency'.
 
 #'
-#' @seealso \code{\link{data.table}}
+#' @seealso \code{\link[data.table]{data.table}}
 
 
 calculateAllele <- function(data, threshold = NULL, sex.rm = FALSE, kit = NULL,

--- a/R/calculateSpike.R
+++ b/R/calculateSpike.R
@@ -48,7 +48,8 @@
 #'
 #' @return data.frame
 #'
-#' @seealso \code{\link{data.table}}
+#' @#' @seealso \code{\link[data.table]{data.table}}
+
 
 
 calculateSpike <- function(data, threshold = NULL, tolerance = 2, kit = NULL,

--- a/R/calculateSpike.R
+++ b/R/calculateSpike.R
@@ -48,7 +48,7 @@
 #'
 #' @return data.frame
 #'
-#' @#' @seealso \code{\link[data.table]{data.table}}
+#' @seealso \code{\link[data.table]{data.table}}
 
 
 

--- a/R/calculateStatistics.r
+++ b/R/calculateStatistics.r
@@ -25,7 +25,7 @@
 #' @param target character column to calculate summary statistics for.
 #' @param group character vector of column(s) to group by, if any.
 #' @param count character column to count unique values in, if any.
-#' @param quant numeric quantile to calculate \{0,1\}, default 0.95.
+##' @param quant numeric quantile to calculate between 0 and 1, default 0.95.
 #' @param decimals numeric number of decimals. Negative does not round.
 #' @param debug logical indicating printing debug information.
 #'

--- a/R/calculateStatistics.r
+++ b/R/calculateStatistics.r
@@ -25,7 +25,7 @@
 #' @param target character column to calculate summary statistics for.
 #' @param group character vector of column(s) to group by, if any.
 #' @param count character column to count unique values in, if any.
-##' @param quant numeric quantile to calculate between 0 and 1, default 0.95.
+#' @param quant numeric quantile to calculate between 0 and 1, default 0.95.
 #' @param decimals numeric number of decimals. Negative does not round.
 #' @param debug logical indicating printing debug information.
 #'

--- a/R/combine_gui.r
+++ b/R/combine_gui.r
@@ -28,7 +28,7 @@
 #' GUI for combining two datasets.
 #'
 #' @details
-#' Simple GUI to combine two datasets using the \code{\link{rbind.fill}}
+#' Simple GUI to combine two datasets using the \code{\link{rbind.fill}}[plyr
 #' function.
 #' NB! Datasets must have identical column names but not necessarily
 #' in the same order.

--- a/R/combine_gui.r
+++ b/R/combine_gui.r
@@ -28,7 +28,7 @@
 #' GUI for combining two datasets.
 #'
 #' @details
-#' Simple GUI to combine two datasets using the \code{\link{rbind.fill}}[plyr
+#' Simple GUI to combine two datasets using the \code{\link[plyr]{rbind.fill}}
 #' function.
 #' NB! Datasets must have identical column names but not necessarily
 #' in the same order.

--- a/R/editData_gui.r
+++ b/R/editData_gui.r
@@ -37,8 +37,8 @@
 #' @param savegui logical indicating if GUI settings should be saved in the environment.
 #' @param data data.frame for instant viewing.
 #' @param name character string with the name of the provided dataset.
-#' @param edit logical TRUE to enable edit (uses \code{\link{gdf}}), FALSE to
-#' view and enable sorting by clicking a column header (uses \code{\link{gtable}}).
+#' @param edit logical TRUE to enable edit (uses \code{\link[gWidgets2]{gdf}}), FALSE to
+#' view and enable sorting by clicking a column header (uses \code{\link[gWidgets2]{gtable}}).
 #' @param debug logical indicating printing debug information.
 #' @param parent widget to get focus when finished.
 #'

--- a/R/ggsave_gui.r
+++ b/R/ggsave_gui.r
@@ -48,7 +48,7 @@
 #' @importFrom utils help
 #' @importFrom grDevices dev.cur dev.list dev.size
 #'
-#' @seealso \code{\link{ggsave}}
+#' @seealso \code{\link[ggplot2]{ggsave}}
 
 ggsave_gui <- function(ggplot = NULL, name = "", env = parent.frame(),
                        savegui = NULL, debug = FALSE, parent = NULL) {

--- a/R/plotDistribution_gui.r
+++ b/R/plotDistribution_gui.r
@@ -50,7 +50,7 @@
 #'
 #' @return TRUE
 #'
-#' @seealso \code{\link{log}}, \code{\link{geom_density}}
+#' @seealso \code{\link[base]{log}}, \code{\link[ggplot2]{geom_density}}
 
 
 plotDistribution_gui <- function(env = parent.frame(), savegui = NULL, debug = FALSE, parent = NULL) {

--- a/R/plotGroups_gui.r
+++ b/R/plotGroups_gui.r
@@ -34,7 +34,7 @@
 #'
 #' @return TRUE
 #'
-#' @seealso \code{\link{stat_ecdf}}
+#' @seealso \code{\link[ggplot2]{stat_ecdf}}
 
 
 plotGroups_gui <- function(env = parent.frame(), savegui = NULL, debug = FALSE, parent = NULL) {


### PR DESCRIPTION
Fix NOTEs about Rd file(s) with Rd \link{} targets missing package anchors in the "Rd cross-references" check.
Adds the missing package anchors.